### PR TITLE
Improve action flow around dealer card and splits

### DIFF
--- a/app/assets/style.css
+++ b/app/assets/style.css
@@ -129,9 +129,8 @@ body {
 
 .grid {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 1rem;
-  align-items: stretch;
 }
 
 .panel {
@@ -142,8 +141,8 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  flex: 1 1 260px;
-  min-width: 260px;
+  flex: 1 1 auto;
+  width: 100%;
 }
 
 .panel header {
@@ -315,16 +314,7 @@ body {
 
 @media (max-width: 900px) {
   .grid {
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    padding-bottom: 0.75rem;
-    scroll-snap-type: x mandatory;
-  }
-
-  .panel {
-    flex: 0 0 280px;
-    min-width: 260px;
-    scroll-snap-align: start;
+    gap: 0.75rem;
   }
 
   .panel-stats .stats-grid {


### PR DESCRIPTION
## Summary
- wait for the dealer upcard before computing the recommended action and lock player inputs until it is registered
- require manual confirmation to split pairs and expose a button similar to the double confirmation flow
- stack dashboard panels vertically and surface contextual notes guiding the user

## Testing
- npm run lint:core

------
https://chatgpt.com/codex/tasks/task_e_68d2147b3de08327b6c6250b2c483798