### PR TITLE
Adjust cut handling and deck controls

### DIFF
--- a/app/assets/style.css
+++ b/app/assets/style.css
@@ -403,6 +403,10 @@ body {
   flex-wrap: wrap;
 }
 
+.push-end {
+  margin-left: auto;
+}
+
 .metrics-row {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- ensure true count keeps using the full shoe after the 60% cut while still reporting penetration statistics
- add a "Troca baralho" control and move "Reiniciar" to the opposite side with a full-session reset flow
- clear pending timers during resets and update the metrics copy/styles to reflect the new layout

## Testing
- npm run lint:core

------
https://chatgpt.com/codex/tasks/task_e_68d4116ee0d48327af15eca5cbe88a64